### PR TITLE
Support for setting game directory, fixed OpenGame.exe debug configuration

### DIFF
--- a/OpenGame.exe.sln
+++ b/OpenGame.exe.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGame.exe", "OpenGame.exe.csproj", "{13A28048-DAF4-4478-8CBB-C4E4B87E8957}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -23,16 +23,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{13A28048-DAF4-4478-8CBB-C4E4B87E8957}.Debug|x86.ActiveCfg = Release|x86
-		{13A28048-DAF4-4478-8CBB-C4E4B87E8957}.Debug|x86.Build.0 = Release|x86
+		{13A28048-DAF4-4478-8CBB-C4E4B87E8957}.Debug|x86.ActiveCfg = Debug|x86
+		{13A28048-DAF4-4478-8CBB-C4E4B87E8957}.Debug|x86.Build.0 = Debug|x86
 		{13A28048-DAF4-4478-8CBB-C4E4B87E8957}.Release|x86.ActiveCfg = Release|x86
 		{13A28048-DAF4-4478-8CBB-C4E4B87E8957}.Release|x86.Build.0 = Release|x86
 		{C91ACA5C-52A1-4433-B150-822779ACCED6}.Debug|x86.ActiveCfg = Debug|x86
 		{C91ACA5C-52A1-4433-B150-822779ACCED6}.Debug|x86.Build.0 = Debug|x86
 		{C91ACA5C-52A1-4433-B150-822779ACCED6}.Release|x86.ActiveCfg = Release|x86
 		{C91ACA5C-52A1-4433-B150-822779ACCED6}.Release|x86.Build.0 = Release|x86
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CommandLineSwitches.cs
+++ b/src/CommandLineSwitches.cs
@@ -7,28 +7,78 @@ namespace OpenGame
 {
     class CommandLineSwitches
     {
+        private enum Key
+        {
+            NONE,
+            GAME
+        }
+
         private bool EnableConsole = false;
         private bool PlayTest = false;
         private bool BattleTest = false;
         private int ForcedRgss = 0;
+        private string GameDirectory = ".";
 
         public CommandLineSwitches(string[] args)
         {
+            Key key = Key.NONE;
+
             foreach (string arg in args)
             {
-                if (arg == "console") EnableConsole = true;
-                if (arg == "test") PlayTest = true;
-                if (arg == "btest") BattleTest = true;
-                if (arg == "rgss1") ForcedRgss = 1;
-                if (arg == "rgss2") ForcedRgss = 2;
-                if (arg == "rgss3") ForcedRgss = 3;
+                if (key != Key.NONE)
+                {
+                    switch (key)
+                    {
+                        case Key.GAME:
+                            GameDirectory = ResolvePath(arg);
+                            break;
+                    }
+
+                    key = Key.NONE;
+                }
+                else
+                {
+                    //Key-pair switches denoted with - sign
+                    //key is used to evaluate the usage of the next argument
+                    if (arg == "-game") key = Key.GAME;
+
+                    if (arg == "console") EnableConsole = true;
+                    if (arg == "test") PlayTest = true;
+                    if (arg == "btest") BattleTest = true;
+                    if (arg == "rgss1") ForcedRgss = 1;
+                    if (arg == "rgss2") ForcedRgss = 2;
+                    if (arg == "rgss3") ForcedRgss = 3;
+                }               
             }
+
+            
+            
             if (EnableConsole) ConsoleWindow.Show();
         }
 
         public int GetForcedRGSSVersion()
         {
             return ForcedRgss;
+        }
+
+        public string GetGameDirectory()
+        {
+            return GameDirectory;
+        }
+
+        private static string ResolvePath(string path)
+        {
+            string s = path;
+
+            //Remove all quotes from the given path
+            int q = s.IndexOf('\u0022');
+            while (q > 0)
+            {
+                s.Remove(q);
+                q = s.IndexOf('\u0022');
+            }
+
+            return s;
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -24,6 +24,8 @@ namespace OpenGame
 
         private static string GameTitle;
 
+        private static string GameDirectory;
+
         private static Ruby Ruby;
 
         public static GameWindow Window;
@@ -55,6 +57,18 @@ namespace OpenGame
 
             //Store the command-line switches
             Switches = new CommandLineSwitches(args);
+
+            //Change working directory to game content (default ".")
+            //The directory will only change if it is valid
+            GameDirectory = Switches.GetGameDirectory();
+            if (Directory.Exists(GameDirectory))
+            {
+                Directory.SetCurrentDirectory(GameDirectory);
+            }
+            else
+            {
+                Program.Error("Game Directory \"" + GameDirectory + "\" not found");
+            }
 
             //Read which version of RGSS we are aiming to emulate
             //or observe the forced version commandline switch


### PR DESCRIPTION
This adds support for a "-game" startup argument that sets the directory for the game. This can be absolute or relative directory.

This makes debugging with multiple projects much easier, we can drop as many project folders as we want into the OpenGame.exe directory and switch between them for testing.

Also fixed the configuration of the debug build for OpenGame.exe, it was actually building the release version.

**Current issues**
- Unknown how this affects the behaviour of games right now (things seem to work fine). This simply changes the working directory, however the AssemblyDirectory remains the same. For this reason, a GameDirectory string has been added to the OpenGame::Program class, it could be that this directory needs to be used for certain needs as opposed to the AssemblyDirectory.
- The OpenGame::CommandLineSwitches class has a static method ::ResolvePath(string path) for removing quotations from a path argument, this should probably be expanded to convert the path into an absolute directory to remove any possible ambiguities (would make debugging a tad easier).
  This method is also better suited as part of a utilities module, this is something to think about later on.
- The use of the "-" symbol as a switch (eg -game, -switch, -port, -username) may need some discussion. There may be a better symbol for describing key:value switches.
- OpenGame::CommandLineSwitches gains an enumerator, ::CommandLineSwitches::Key. Syntax styling for this needs some discussion. I have taken the initiative and gone for upper-case keys.
- Behaviour for unexpected -game values may need further testing. For now, the directory is checked and the Program will Error if the directory does not exist.
- **Important** OpenGame.exe.sln has been updated with my visual studio version (13), this probably needs to be undone.
