### PR TITLE
Path resolution and window background 2 tiling

### DIFF
--- a/RGSS/RGSS/Window.cs
+++ b/RGSS/RGSS/Window.cs
@@ -213,15 +213,60 @@ public class Window : Drawable
                 GL.TexCoord2(0f, 0.5f);
                 GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
 
-                //background layer 2 - NEEDS TO BE TILED
-                GL.TexCoord2(0f, 0.5f);
-                GL.Vertex3(aax + 2, aay + 2, 0.2f);
-                GL.TexCoord2(0.5f, 0.5f);
-                GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
-                GL.TexCoord2(0.5f, 1f);
-                GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
-                GL.TexCoord2(0f, 1f);
-                GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
+                //background layer 2 - Drawn top to bottom, left to right
+                int tileX = aax + 2;
+                int endX = aaw - 4;
+
+                float tileUVX = 0.5f;
+                int tileEndX = 64;
+
+                int xx; //Outside of loop so it can be used for the right column
+                for (xx = 0; xx < endX; xx += 64)
+                {
+                    if (xx + tileEndX > endX)
+                    {
+                        tileEndX = endX - xx;
+                        tileUVX = (float)tileEndX / 128.0f;
+                    }
+
+                    int tileY = aay + 2;
+                    int endY = aah - 64 - 4;
+
+                    int yy; //Outside of loop so it can be used for the bottom row
+                    for ( yy = 0; yy < endY; yy += 64)
+                    {
+                        GL.TexCoord2(0f, 0.5f);
+                        GL.Vertex3(tileX + xx, tileY + yy, 0.2f);
+
+                        GL.TexCoord2(tileUVX, 0.5f);
+                        GL.Vertex3(tileX + xx + tileEndX, tileY + yy, 0.2f);
+
+                        GL.TexCoord2(tileUVX, 1.0f);
+                        GL.Vertex3(tileX + xx + tileEndX, tileY + yy + 64, 0.2f);
+
+                        GL.TexCoord2(0f, 1.0f);
+                        GL.Vertex3(tileX + xx, tileY + yy + 64, 0.2f);
+                    }
+
+                    if (endY < 0)
+                    {
+                        endY += 64; //Corrects for when height < 64
+                    }
+                    
+                    float endUVY = 0.5f + ((float)endY / 128.0f);
+
+                    GL.TexCoord2(0f, 0.5f);
+                    GL.Vertex3(tileX + xx, tileY + yy, 0.2f);
+
+                    GL.TexCoord2(tileUVX, 0.5f);
+                    GL.Vertex3(tileX + xx + tileEndX, tileY + yy, 0.2f);
+
+                    GL.TexCoord2(tileUVX, endUVY);
+                    GL.Vertex3(tileX + xx + tileEndX, tileY + yy + endY, 0.2f);
+
+                    GL.TexCoord2(0f, endUVY);
+                    GL.Vertex3(tileX + xx, tileY + yy + endY, 0.2f);
+                }
 
                 //corners
                 GL.Color4(1.0f, 1.0f, 1.0f, 1f);

--- a/RGSS/RGSS/Window.cs
+++ b/RGSS/RGSS/Window.cs
@@ -233,7 +233,7 @@ public class Window : Drawable
                     int endY = aah - 64 - 4;
 
                     int yy; //Outside of loop so it can be used for the bottom row
-                    for ( yy = 0; yy < endY; yy += 64)
+                    for (yy = 0; yy < endY; yy += 64)
                     {
                         GL.TexCoord2(0f, 0.5f);
                         GL.Vertex3(tileX + xx, tileY + yy, 0.2f);

--- a/src/RuntimeConfiguration.cs
+++ b/src/RuntimeConfiguration.cs
@@ -73,13 +73,7 @@ namespace OpenGame
                     case "-game":
                         i++; //pre-emptively increment to the accompanying parameter
                         //Set the DataPath where we will look for game files
-                        DataPath = parameters[i].Replace("\"", "");
-
-                        //Make sure the DataPath correctly ends with the OS' path delimiter
-                        if (!DataPath.EndsWith(PathDelimiter))
-                        {
-                            DataPath += PathDelimiter;
-                        }
+                        DataPath = ResolvePath( parameters[i].Replace("\"", "") );
                         break;
                     case "-rtp":
                         i++; //pre-emptively increment to the accompanying parameter
@@ -266,6 +260,30 @@ namespace OpenGame
             }
 
             return title;
+        }
+
+        // Here to make sure any OS paths are correctly formatted (ending with delimiter)
+        private string ResolvePath(string path)
+        {
+            string s;
+
+            //Windows software usually supports / delimiters, so we can convert any of those to \\
+            if (WindowsOS && path.EndsWith("/"))
+            {
+                s = path.Replace("/", PathDelimiter);
+            }
+            else
+            {
+                s = path;
+            }
+
+            //Make sure the DataPath correctly ends with the OS' path delimiter
+            if (!s.EndsWith(PathDelimiter))
+            {
+                s += PathDelimiter;
+            }
+
+            return s;
         }
 
         // These tests are run once at startup to determine whether the Operating System is Windows.

--- a/src/RuntimeConfiguration.cs
+++ b/src/RuntimeConfiguration.cs
@@ -73,7 +73,7 @@ namespace OpenGame
                     case "-game":
                         i++; //pre-emptively increment to the accompanying parameter
                         //Set the DataPath where we will look for game files
-                        DataPath = ResolvePath( parameters[i].Replace("\"", "") );
+                        DataPath = ResolvePath(parameters[i].Replace("\"", ""));
                         break;
                     case "-rtp":
                         i++; //pre-emptively increment to the accompanying parameter

--- a/src/RuntimeConfiguration.cs
+++ b/src/RuntimeConfiguration.cs
@@ -20,6 +20,7 @@ namespace OpenGame
         private int DefaultResolutionWidth;
         private int DefaultResolutionHeight;
         private List<String> ResourcePaths;
+        private string PathDelimiter;
 
         public RuntimeConfiguration(string[] parameters)
         {
@@ -32,18 +33,27 @@ namespace OpenGame
             // Is this a Windows targeted build?
             WindowsOS = CheckIfWindowsOS();
             
-            // Enable the console if applicable
-            if (WindowsOS && Debug)
+            if (WindowsOS)
             {
-                var handle = GetConsoleWindow();
-                if (handle == IntPtr.Zero)
+                PathDelimiter = "\\";
+
+                // Enable the console if applicable
+                if (Debug)
                 {
-                    AllocConsole();
-                }
-                else
-                {
-                    ShowWindow(handle, SW_SHOW);
-                }
+                    var handle = GetConsoleWindow();
+                    if (handle == IntPtr.Zero)
+                    {
+                        AllocConsole();
+                    }
+                    else
+                    {
+                        ShowWindow(handle, SW_SHOW);
+                    }
+                }                
+            }
+            else
+            {
+                PathDelimiter = "/";
             }
 
             // Setup command-line parameter defaults
@@ -64,6 +74,12 @@ namespace OpenGame
                         i++; //pre-emptively increment to the accompanying parameter
                         //Set the DataPath where we will look for game files
                         DataPath = parameters[i].Replace("\"", "");
+
+                        //Make sure the DataPath correctly ends with the OS' path delimiter
+                        if (!DataPath.EndsWith(PathDelimiter))
+                        {
+                            DataPath += PathDelimiter;
+                        }
                         break;
                     case "-rtp":
                         i++; //pre-emptively increment to the accompanying parameter


### PR DESCRIPTION
Added path resolution for -game switch as the recent re-factor made certain permutations no-longer work.

This involves the method ::ResolvePath() making a return.

Window background layer 2 is tiled with extra geometry. There's a lot of looping involved and there could be some room for mathematical optimisations.
