### PR TITLE
Added deferred Actions for Graphics RGSS class, any GPU commands done…

### DIFF
--- a/RGSS/RGSS/Bitmap.cs
+++ b/RGSS/RGSS/Bitmap.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-
 public class Bitmap
 {
     public Font font;
@@ -20,27 +19,36 @@ public class Bitmap
     private bool disposed = false;
     public string name = "";
 
+    internal Action syncBitmap; //this.SyncBitmap() call
+
     public Bitmap(string filename)
     {
+        syncBitmap = this.SyncBitmap;
+
         font = Font.default_font;
         LoadTexture(filename);
     }
 
     public Bitmap(int w, int h)
     {
+        syncBitmap = this.SyncBitmap;
+
         font = Font.default_font;
         CreateTexture(w, h);
     }
 
     public Bitmap(Bitmap b)
     {
+        syncBitmap = this.SyncBitmap;
+
         font = b.font;
         name = b.name;
         width_ = b.width();
         height_ = b.height();
         bmp = (System.Drawing.Bitmap) b.bmp.Clone();
         disposed = b.disposed;
-        SyncBitmap();
+
+        Graphics.deferred_action_add(syncBitmap);
     }
 
     private void CreateTexture(int w, int h)
@@ -172,7 +180,8 @@ public class Bitmap
     public void set_pixel(int x, int y, Color rc){
         System.Drawing.Color c = System.Drawing.Color.FromArgb(rc.alpha, rc.red, rc.green, rc.blue);
         bmp.SetPixel(x, y, c);
-        SyncBitmap();
+
+        Graphics.deferred_action_add(syncBitmap);
     }
 
     public void stretch_blt(Rect dest, Bitmap src_bitmap, Rect src_rect, int opacity)
@@ -183,7 +192,8 @@ public class Bitmap
         System.Drawing.Rectangle destination = new System.Drawing.Rectangle(new Point(dest.x, dest.y), new Size(dest.width, dest.height));
         g.DrawImage(src_bitmap.bmp, destination, source, GraphicsUnit.Pixel);
         g.Dispose();
-        SyncBitmap();
+
+        Graphics.deferred_action_add(syncBitmap);
     }
 
     public void draw_text(int x, int y, int width, int height, int message)
@@ -276,7 +286,8 @@ public class Bitmap
         DrawStringShrink2Fit(g, message, f, brush, destination, stringFormat);
         g.Dispose();
         brush.Dispose();
-        SyncBitmap();
+
+        Graphics.deferred_action_add(syncBitmap);
     }
 
     public Rect text_size(string message)
@@ -306,7 +317,10 @@ public class Bitmap
         {
             g.FillRectangle(br, new Rectangle(ax, ay, aw, ah));
         }
-        SyncBitmap();
+
+        
+        Graphics.deferred_action_add(syncBitmap);
+
         g.Dispose();
     }
 
@@ -323,7 +337,8 @@ public class Bitmap
         {
             g.FillRectangle(br, new Rectangle(ax, ay, aw, ah));
         }
-        SyncBitmap();
+        Graphics.deferred_action_add(syncBitmap);
+
         g.Dispose();
     }
 
@@ -367,7 +382,9 @@ public class Bitmap
         {
             g.FillRectangle(br, new Rectangle(ax, ay, aw, ah));
         }
-        SyncBitmap();
+
+        Graphics.deferred_action_add(syncBitmap);
+
         g.Dispose();
     }
 

--- a/RGSS/RGSS/Bitmap.cs
+++ b/RGSS/RGSS/Bitmap.cs
@@ -317,7 +317,6 @@ public class Bitmap
         {
             g.FillRectangle(br, new Rectangle(ax, ay, aw, ah));
         }
-
         
         Graphics.deferred_action_add(syncBitmap);
 

--- a/RGSS/RGSS/Graphics.cs
+++ b/RGSS/RGSS/Graphics.cs
@@ -22,7 +22,7 @@ public class Graphics
     public static Viewport default_viewport;
     public static GameWindow Window;
 
-    internal static Stack<Action> deferredActions = new Stack<Action>();
+    internal static Queue<Action> deferredActions = new Queue<Action>();
     internal static Mutex deferredMutex = new Mutex();
     internal static bool hasDeferredActions = false;
     internal static int mainThreadId;
@@ -53,12 +53,8 @@ public class Graphics
         {
             deferredMutex.WaitOne();
 
-            int cc = deferredActions.Count();
-
-            Action action;
-            while (cc-- != 0)
+            foreach (Action action in deferredActions)
             {
-                action = deferredActions.Pop();
                 action();
             }
 
@@ -79,7 +75,7 @@ public class Graphics
         {
             deferredMutex.WaitOne();
 
-            deferredActions.Push(action);
+            deferredActions.Enqueue(action);
             hasDeferredActions = true;
 
             deferredMutex.ReleaseMutex();

--- a/RGSS/RGSS/Window.cs
+++ b/RGSS/RGSS/Window.cs
@@ -191,7 +191,9 @@ public class Window : Drawable
             GL.Enable(EnableCap.Texture2D);
             GL.BindTexture(TextureTarget.Texture2D, windowskin.txid);
 
-            GL.Color4(1.0f, 1.0f, 1.0f, (1f / 255f) * (float)back_opacity);
+            float winAlpha = (float)back_opacity / 255.0f;
+
+            GL.Color4(1.0f, 1.0f, 1.0f, winAlpha);
 
             //clone position values to mod them for openness
             int mod_y = (int)(((1f / 255f) * (float) openness) * height);
@@ -271,8 +273,6 @@ public class Window : Drawable
                 //Tint the background layers
                 if (tone.red != 0 || tone.green != 0 || tone.blue != 0)
                 {
-                    float alpha = (float)back_opacity / 255.0f;
-
                     GL.End();
 
                     GL.Disable(EnableCap.Texture2D);
@@ -280,9 +280,9 @@ public class Window : Drawable
 
                     if (tone.red > 0 || tone.green > 0 || tone.blue > 0)
                     {
-                        float addR = (tone.red > 0 ? (float)tone.red / 255.0f * alpha : 0.0f);
-                        float addG = (tone.green > 0 ? (float)tone.green / 255.0f * alpha : 0.0f);
-                        float addB = (tone.blue > 0 ? (float)tone.blue / 255.0f * alpha : 0.0f);
+                        float addR = (tone.red > 0 ? (float)tone.red / 255.0f * winAlpha : 0.0f);
+                        float addG = (tone.green > 0 ? (float)tone.green / 255.0f * winAlpha : 0.0f);
+                        float addB = (tone.blue > 0 ? (float)tone.blue / 255.0f * winAlpha : 0.0f);
 
                         GL.Color4(addR, addG, addB, 0.0f);
                         GL.BlendEquation(BlendEquationMode.FuncAdd);
@@ -299,9 +299,9 @@ public class Window : Drawable
 
                     if (tone.red < 0 || tone.green < 0 || tone.blue < 0)
                     {
-                        float subR = (tone.red < 0 ? -(float)tone.red / 255.0f * alpha : 0.0f);
-                        float subG = (tone.green < 0 ? -(float)tone.green / 255.0f * alpha : 0.0f);
-                        float subB = (tone.blue < 0 ? -(float)tone.blue / 255.0f * alpha : 0.0f);
+                        float subR = (tone.red < 0 ? -(float)tone.red / 255.0f * winAlpha : 0.0f);
+                        float subG = (tone.green < 0 ? -(float)tone.green / 255.0f * winAlpha : 0.0f);
+                        float subB = (tone.blue < 0 ? -(float)tone.blue / 255.0f * winAlpha : 0.0f);
 
                         GL.Color4(subR, subG, subB, 0.0f);
                         GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
@@ -318,7 +318,7 @@ public class Window : Drawable
 
                     GL.BlendEquation(BlendEquationMode.FuncAdd);
                     GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
-                    GL.Color4(1.0f, 1.0f, 1.0f, alpha);
+                    GL.Color4(1.0f, 1.0f, 1.0f, winAlpha);
                     GL.Enable(EnableCap.Texture2D);
 
                     GL.Begin(BeginMode.Quads);

--- a/RGSS/RGSS/Window.cs
+++ b/RGSS/RGSS/Window.cs
@@ -188,12 +188,10 @@ public class Window : Drawable
         //windowskin
         if (windowskin != null && windowskin.txid != 0 && back_opacity > 0 && openness >= 0)
         {
-            float alpha = 1.0f; // (1.0f / 255.0f) * (float)back_opacity;
-
             GL.Enable(EnableCap.Texture2D);
             GL.BindTexture(TextureTarget.Texture2D, windowskin.txid);
 
-            GL.Color4(1.0f, 1.0f, 1.0f, alpha);
+            GL.Color4(1.0f, 1.0f, 1.0f, (1f / 255f) * (float)back_opacity);
 
             //clone position values to mod them for openness
             int mod_y = (int)(((1f / 255f) * (float) openness) * height);
@@ -204,7 +202,7 @@ public class Window : Drawable
             if (mod_y > 1)
             {
                 GL.Begin(BeginMode.Quads);
-                
+
                 //background layer 1
                 GL.TexCoord2(0f, 0f);
                 GL.Vertex3(aax + 2, aay + 2, 0.2f);
@@ -273,6 +271,8 @@ public class Window : Drawable
                 //Tint the background layers
                 if (tone.red != 0 || tone.green != 0 || tone.blue != 0)
                 {
+                    float alpha = (float)back_opacity / 255.0f;
+
                     GL.End();
 
                     GL.Disable(EnableCap.Texture2D);

--- a/RGSS/RGSS/Window.cs
+++ b/RGSS/RGSS/Window.cs
@@ -186,14 +186,10 @@ public class Window : Drawable
         if (!visible || opacity <= 0 || disposed) return;
 
         //windowskin
-        if (windowskin != null && windowskin.txid != 0 && back_opacity > 0 && openness >= 0)
+        if (windowskin != null && windowskin.txid != 0 && openness >= 0)
         {
             GL.Enable(EnableCap.Texture2D);
             GL.BindTexture(TextureTarget.Texture2D, windowskin.txid);
-
-            float winAlpha = (float)back_opacity / 255.0f;
-
-            GL.Color4(1.0f, 1.0f, 1.0f, winAlpha);
 
             //clone position values to mod them for openness
             int mod_y = (int)(((1f / 255f) * (float) openness) * height);
@@ -203,129 +199,144 @@ public class Window : Drawable
             int aah = mod_y;
             if (mod_y > 1)
             {
-                GL.Begin(BeginMode.Quads);
-
-                //background layer 1
-                GL.TexCoord2(0f, 0f);
-                GL.Vertex3(aax + 2, aay + 2, 0.2f);
-                GL.TexCoord2(0.5f, 0f);
-                GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
-                GL.TexCoord2(0.5f, 0.5f);
-                GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
-                GL.TexCoord2(0f, 0.5f);
-                GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
-
-                //background layer 2 - Drawn top to bottom, left to right
-                int tileX = aax + 2;
-                int endX = aaw - 4;
-
-                float tileUVX = 0.5f;
-                int tileEndX = 64;
-
-                int xx; //Outside of loop so it can be used for the right column
-                for (xx = 0; xx < endX; xx += 64)
+                if (back_opacity > 0)
                 {
-                    if (xx + tileEndX > endX)
-                    {
-                        tileEndX = endX - xx;
-                        tileUVX = (float)tileEndX / 128.0f;
-                    }
+                    float bgAlpha = (float)back_opacity / 255.0f;
 
-                    int tileY = aay + 2;
-                    int endY = aah - 64 - 4;
+                    GL.Color4(1.0f, 1.0f, 1.0f, bgAlpha);
 
-                    int yy; //Outside of loop so it can be used for the bottom row
-                    for (yy = 0; yy < endY; yy += 64)
+                    GL.Begin(BeginMode.Quads);
+
+                    //background layer 1
+                    GL.TexCoord2(0f, 0f);
+                    GL.Vertex3(aax + 2, aay + 2, 0.2f);
+                    GL.TexCoord2(0.5f, 0f);
+                    GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
+                    GL.TexCoord2(0.5f, 0.5f);
+                    GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
+                    GL.TexCoord2(0f, 0.5f);
+                    GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
+
+                    GL.End();
+
+                    GL.BlendFuncSeparate(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha, BlendingFactorSrc.Zero, BlendingFactorDest.One);
+
+                    GL.Begin(BeginMode.Quads);
+
+                    //background layer 2 - Drawn top to bottom, left to right
+                    int tileX = aax + 2;
+                    int endX = aaw - 4;
+
+                    float tileUVX = 0.5f;
+                    int tileEndX = 64;
+
+                    int xx; //Outside of loop so it can be used for the right column
+                    for (xx = 0; xx < endX; xx += 64)
                     {
+                        if (xx + tileEndX > endX)
+                        {
+                            tileEndX = endX - xx;
+                            tileUVX = (float)tileEndX / 128.0f;
+                        }
+
+                        int tileY = aay + 2;
+                        int endY = aah - 64 - 4;
+
+                        int yy; //Outside of loop so it can be used for the bottom row
+                        for (yy = 0; yy < endY; yy += 64)
+                        {
+                            GL.TexCoord2(0f, 0.5f);
+                            GL.Vertex3(tileX + xx, tileY + yy, 0.2f);
+
+                            GL.TexCoord2(tileUVX, 0.5f);
+                            GL.Vertex3(tileX + xx + tileEndX, tileY + yy, 0.2f);
+
+                            GL.TexCoord2(tileUVX, 1.0f);
+                            GL.Vertex3(tileX + xx + tileEndX, tileY + yy + 64, 0.2f);
+
+                            GL.TexCoord2(0f, 1.0f);
+                            GL.Vertex3(tileX + xx, tileY + yy + 64, 0.2f);
+                        }
+
+                        if (endY < 0)
+                        {
+                            endY += 64; //Corrects for when height < 64
+                        }
+
+                        float endUVY = 0.5f + ((float)endY / 128.0f);
+
                         GL.TexCoord2(0f, 0.5f);
                         GL.Vertex3(tileX + xx, tileY + yy, 0.2f);
 
                         GL.TexCoord2(tileUVX, 0.5f);
                         GL.Vertex3(tileX + xx + tileEndX, tileY + yy, 0.2f);
 
-                        GL.TexCoord2(tileUVX, 1.0f);
-                        GL.Vertex3(tileX + xx + tileEndX, tileY + yy + 64, 0.2f);
+                        GL.TexCoord2(tileUVX, endUVY);
+                        GL.Vertex3(tileX + xx + tileEndX, tileY + yy + endY, 0.2f);
 
-                        GL.TexCoord2(0f, 1.0f);
-                        GL.Vertex3(tileX + xx, tileY + yy + 64, 0.2f);
+                        GL.TexCoord2(0f, endUVY);
+                        GL.Vertex3(tileX + xx, tileY + yy + endY, 0.2f);
                     }
 
-                    if (endY < 0)
-                    {
-                        endY += 64; //Corrects for when height < 64
-                    }
-                    
-                    float endUVY = 0.5f + ((float)endY / 128.0f);
-
-                    GL.TexCoord2(0f, 0.5f);
-                    GL.Vertex3(tileX + xx, tileY + yy, 0.2f);
-
-                    GL.TexCoord2(tileUVX, 0.5f);
-                    GL.Vertex3(tileX + xx + tileEndX, tileY + yy, 0.2f);
-
-                    GL.TexCoord2(tileUVX, endUVY);
-                    GL.Vertex3(tileX + xx + tileEndX, tileY + yy + endY, 0.2f);
-
-                    GL.TexCoord2(0f, endUVY);
-                    GL.Vertex3(tileX + xx, tileY + yy + endY, 0.2f);
-                }
-
-                //Tint the background layers
-                if (tone.red != 0 || tone.green != 0 || tone.blue != 0)
-                {
                     GL.End();
 
-                    GL.Disable(EnableCap.Texture2D);
-                    GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.One);
-
-                    if (tone.red > 0 || tone.green > 0 || tone.blue > 0)
+                    //Tint the background layers
+                    if (tone.red != 0 || tone.green != 0 || tone.blue != 0)
                     {
-                        float addR = (tone.red > 0 ? (float)tone.red / 255.0f * winAlpha : 0.0f);
-                        float addG = (tone.green > 0 ? (float)tone.green / 255.0f * winAlpha : 0.0f);
-                        float addB = (tone.blue > 0 ? (float)tone.blue / 255.0f * winAlpha : 0.0f);
+                        GL.Disable(EnableCap.Texture2D);
+                        GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.One);
 
-                        GL.Color4(addR, addG, addB, 0.0f);
+                        if (tone.red > 0 || tone.green > 0 || tone.blue > 0)
+                        {
+                            float addR = (tone.red > 0 ? (float)tone.red / 255.0f * bgAlpha : 0.0f);
+                            float addG = (tone.green > 0 ? (float)tone.green / 255.0f * bgAlpha : 0.0f);
+                            float addB = (tone.blue > 0 ? (float)tone.blue / 255.0f * bgAlpha : 0.0f);
+
+                            GL.Color4(addR, addG, addB, 0.0f);
+                            GL.BlendEquation(BlendEquationMode.FuncAdd);
+
+                            GL.Begin(BeginMode.Quads);
+
+                            GL.Vertex3(aax + 2, aay + 2, 0.2f);
+                            GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
+                            GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
+                            GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
+
+                            GL.End();
+                        }
+
+                        if (tone.red < 0 || tone.green < 0 || tone.blue < 0)
+                        {
+                            float subR = (tone.red < 0 ? -(float)tone.red / 255.0f * bgAlpha : 0.0f);
+                            float subG = (tone.green < 0 ? -(float)tone.green / 255.0f * bgAlpha : 0.0f);
+                            float subB = (tone.blue < 0 ? -(float)tone.blue / 255.0f * bgAlpha : 0.0f);
+
+                            GL.Color4(subR, subG, subB, 0.0f);
+                            GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
+
+                            GL.Begin(BeginMode.Quads);
+
+                            GL.Vertex3(aax + 2, aay + 2, 0.2f);
+                            GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
+                            GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
+                            GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
+
+                            GL.End();
+                        }
+
                         GL.BlendEquation(BlendEquationMode.FuncAdd);
 
-                        GL.Begin(BeginMode.Quads);
-
-                        GL.Vertex3(aax + 2, aay + 2, 0.2f);
-                        GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
-                        GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
-                        GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
-
-                        GL.End();
+                        GL.Enable(EnableCap.Texture2D);
                     }
 
-                    if (tone.red < 0 || tone.green < 0 || tone.blue < 0)
-                    {
-                        float subR = (tone.red < 0 ? -(float)tone.red / 255.0f * winAlpha : 0.0f);
-                        float subG = (tone.green < 0 ? -(float)tone.green / 255.0f * winAlpha : 0.0f);
-                        float subB = (tone.blue < 0 ? -(float)tone.blue / 255.0f * winAlpha : 0.0f);
-
-                        GL.Color4(subR, subG, subB, 0.0f);
-                        GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
-
-                        GL.Begin(BeginMode.Quads);
-
-                        GL.Vertex3(aax + 2, aay + 2, 0.2f);
-                        GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
-                        GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
-                        GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
-
-                        GL.End();
-                    }
-
-                    GL.BlendEquation(BlendEquationMode.FuncAdd);
                     GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
-                    GL.Color4(1.0f, 1.0f, 1.0f, winAlpha);
-                    GL.Enable(EnableCap.Texture2D);
-
-                    GL.Begin(BeginMode.Quads);
                 }
 
                 //corners
                 GL.Color4(1.0f, 1.0f, 1.0f, 1f);
+
+                GL.Begin(BeginMode.Quads);
+
                 //topleft corner
                 float uvtile = 0.125f; // 1f / 8f
                 GL.TexCoord2(0.5f, 0f);

--- a/RGSS/RGSS/Window.cs
+++ b/RGSS/RGSS/Window.cs
@@ -188,10 +188,12 @@ public class Window : Drawable
         //windowskin
         if (windowskin != null && windowskin.txid != 0 && back_opacity > 0 && openness >= 0)
         {
+            float alpha = 1.0f; // (1.0f / 255.0f) * (float)back_opacity;
+
             GL.Enable(EnableCap.Texture2D);
             GL.BindTexture(TextureTarget.Texture2D, windowskin.txid);
 
-            GL.Color4(1.0f, 1.0f, 1.0f, (1f / 255f) * (float)back_opacity);
+            GL.Color4(1.0f, 1.0f, 1.0f, alpha);
 
             //clone position values to mod them for openness
             int mod_y = (int)(((1f / 255f) * (float) openness) * height);
@@ -202,7 +204,7 @@ public class Window : Drawable
             if (mod_y > 1)
             {
                 GL.Begin(BeginMode.Quads);
-
+                
                 //background layer 1
                 GL.TexCoord2(0f, 0f);
                 GL.Vertex3(aax + 2, aay + 2, 0.2f);
@@ -266,6 +268,60 @@ public class Window : Drawable
 
                     GL.TexCoord2(0f, endUVY);
                     GL.Vertex3(tileX + xx, tileY + yy + endY, 0.2f);
+                }
+
+                //Tint the background layers
+                if (tone.red != 0 || tone.green != 0 || tone.blue != 0)
+                {
+                    GL.End();
+
+                    GL.Disable(EnableCap.Texture2D);
+                    GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.One);
+
+                    if (tone.red > 0 || tone.green > 0 || tone.blue > 0)
+                    {
+                        float addR = (tone.red > 0 ? (float)tone.red / 255.0f * alpha : 0.0f);
+                        float addG = (tone.green > 0 ? (float)tone.green / 255.0f * alpha : 0.0f);
+                        float addB = (tone.blue > 0 ? (float)tone.blue / 255.0f * alpha : 0.0f);
+
+                        GL.Color4(addR, addG, addB, 0.0f);
+                        GL.BlendEquation(BlendEquationMode.FuncAdd);
+
+                        GL.Begin(BeginMode.Quads);
+
+                        GL.Vertex3(aax + 2, aay + 2, 0.2f);
+                        GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
+                        GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
+                        GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
+
+                        GL.End();
+                    }
+
+                    if (tone.red < 0 || tone.green < 0 || tone.blue < 0)
+                    {
+                        float subR = (tone.red < 0 ? -(float)tone.red / 255.0f * alpha : 0.0f);
+                        float subG = (tone.green < 0 ? -(float)tone.green / 255.0f * alpha : 0.0f);
+                        float subB = (tone.blue < 0 ? -(float)tone.blue / 255.0f * alpha : 0.0f);
+
+                        GL.Color4(subR, subG, subB, 0.0f);
+                        GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
+
+                        GL.Begin(BeginMode.Quads);
+
+                        GL.Vertex3(aax + 2, aay + 2, 0.2f);
+                        GL.Vertex3(aax + aaw - 2, aay + 2, 0.2f);
+                        GL.Vertex3(aax + aaw - 2, aay + aah - 2, 0.2f);
+                        GL.Vertex3(aax + 2, aay + aah - 2, 0.2f);
+
+                        GL.End();
+                    }
+
+                    GL.BlendEquation(BlendEquationMode.FuncAdd);
+                    GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
+                    GL.Color4(1.0f, 1.0f, 1.0f, alpha);
+                    GL.Enable(EnableCap.Texture2D);
+
+                    GL.Begin(BeginMode.Quads);
                 }
 
                 //corners

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -66,10 +66,10 @@ namespace OpenGame
             GL.MatrixMode(MatrixMode.Projection);
             GL.LoadIdentity();
             GL.Ortho(0, Runtime.GetDefaultResolutionWidth(), Runtime.GetDefaultResolutionHeight(), 0, -1, 1);
-            GL.Enable(EnableCap.Texture2D);
-            GL.Enable(EnableCap.Blend);
-            GL.Disable(EnableCap.DepthTest);
-            GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
+            GL.Enable(EnableCap.Texture2D); //TODO: Only enable textures where they are needed (fixed function performance hit)
+            GL.Enable(EnableCap.Blend); //TODO: blend should only be enabled where it is needed! Needless performance hit here
+            GL.Disable(EnableCap.DepthTest); //TODO: Remove depth buffer from context if depth test is not used
+            GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha); //TODO: move this to only where it is needed to be used
             GL.ClearColor(0f, 0f, 0f, 1.0f);
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
             Window.SwapBuffers();

--- a/src/RuntimeConfiguration.cs
+++ b/src/RuntimeConfiguration.cs
@@ -277,7 +277,7 @@ namespace OpenGame
                 s = path;
             }
 
-            //Make sure the DataPath correctly ends with the OS' path delimiter
+            //Make sure the path correctly ends with the OS' path delimiter
             if (!s.EndsWith(PathDelimiter))
             {
                 s += PathDelimiter;


### PR DESCRIPTION
… through fiber should be added as a deferred Action. See Bitmap.cs for exmaples. This lets text rendering happen on the GL context thread.

This fixes text rendering;
![win_tint](https://cloud.githubusercontent.com/assets/1824671/8969509/f284329e-363b-11e5-93b6-06946e99720f.png)

The way deferred Actions works may need revising as any dependency on the results of SyncBitmap in the Bitmap class is not taken into account (SyncBitmap is presumed to be entirely on the GL upload side of things).

EDIT: Changed from stack to queue because stack was a dumb choice from the start (wtf was I thinking)

This also means there could be 1 frame latency difference compared with the original RGSS implementation; this could be a problem in the future but at the moment it seems to work fine.

TODO: Get rid of the stupid mutex by using a thread safe queue. Apparently these exist as part of the concurrent collection.
