### PR TITLE
Improve dll path combining

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -15,3 +15,4 @@ have not signed this file cannot be accepted. You may include your email address
 
 Jason B. (avarisc)    
 Felix J. (Xilef)
+Mattias C. (mattiascibien)

--- a/src/Launcher.cs
+++ b/src/Launcher.cs
@@ -24,7 +24,7 @@ namespace OpenGame
         {
             //Console.WriteLine("Resolving dll " + args.Name);
             string folderPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string assemblyPath = Path.Combine(folderPath + @"/System/", new AssemblyName(args.Name).Name + ".dll");
+            string assemblyPath = Path.Combine(folderPath, @"System", new AssemblyName(args.Name).Name + ".dll");
             if (File.Exists(assemblyPath) == false) return null;
             Assembly assembly = Assembly.LoadFrom(assemblyPath);
             return assembly;


### PR DESCRIPTION
Hello,
I have applied a small fix on dll resolution. `Path.Combine` contains a overload with a params[] attribute, therefore without the need to concatenate the string with + "/System/". This implementation is also available in [Mono](https://github.com/mono/mono/blob/master/mcs/class/corlib/System.IO/Path.cs#L782) and is safer than concatenating string manually.

Have a nice day.
